### PR TITLE
Case insensitive tool and agent names

### DIFF
--- a/src/crewai/agents/executor.py
+++ b/src/crewai/agents/executor.py
@@ -201,7 +201,9 @@ class CrewAgentExecutor(AgentExecutor):
                 observation = InvalidTool().run(
                     {
                         "requested_tool_name": agent_action.tool,
-                        "available_tool_names": [tool.name for tool in name_to_tool_map.values()],
+                        "available_tool_names": [
+                            tool.name for tool in name_to_tool_map.values()
+                        ],
                     },
                     verbose=self.verbose,
                     color=None,

--- a/src/crewai/agents/executor.py
+++ b/src/crewai/agents/executor.py
@@ -170,8 +170,9 @@ class CrewAgentExecutor(AgentExecutor):
             output = action.copy()
             output.tool_input = f"tool:{action.tool}|input:{action.tool_input}"
             output.tool = tool.name
-            name_to_tool_map[tool.name.casefold()] = tool
-            color_mapping[tool.name] = color_mapping[action.tool]
+            tool_name = tool.name.casefold()
+            name_to_tool_map[tool_name] = tool
+            color_mapping[tool_name] = color_mapping[action.tool.casefold()]
 
         actions: List[AgentAction]
         actions = [output] if isinstance(output, AgentAction) else output

--- a/src/crewai/tools/agent_tools.py
+++ b/src/crewai/tools/agent_tools.py
@@ -51,10 +51,11 @@ class AgentTools(BaseModel):
         if not agent or not task or not context:
             return self.i18n.errors("agent_tool_missing_param")
 
+        agent_name = agent.strip().casefold()
         agent = [
             available_agent
             for available_agent in self.agents
-            if available_agent.role == agent
+            if available_agent.role.casefold() == agent_name
         ]
 
         if not agent:

--- a/src/crewai/tools/cache_tools.py
+++ b/src/crewai/tools/cache_tools.py
@@ -8,7 +8,7 @@ class CacheTools(BaseModel):
     """Default tools to hit the cache."""
 
     model_config = ConfigDict(arbitrary_types_allowed=True)
-    name: str = "Hit Cache"
+    name: str = "hit cache"
     cache_handler: CacheHandler = Field(
         description="Cache Handler for the crew",
         default=CacheHandler(),


### PR DESCRIPTION
Thanks for the great toolset. 

Had tried it with a locally running _Mistral 7b_ and found that this LLM, while being very usable on commodity HW, doesn't always get case and leading/trailing spaces right. With this change the trip planner example started to work.

This PR adds `strip().casefold()` for agent names and `casefold()` for tool names (as `strip()` was existing already)
