### PR TITLE
Additional sequential process to return full task output

### DIFF
--- a/src/crewai/crew.py
+++ b/src/crewai/crew.py
@@ -175,7 +175,7 @@ class Crew(BaseModel):
             role = task.agent.role if task.agent is not None else "None"
             self._logger.log("debug", f"[{role}] Task output: {task_output}\n\n")
     
-            task_outputs.append(task_output)
+            task_outputs.append(task.output)
     
         if self.max_rpm:
             self._rpm_controller.stop_rpm_counter()


### PR DESCRIPTION
# Add Full Sequential Task Output Feature

## Overview
This pull request introduces a new feature to the existing codebase that enhances the functionality of sequential task execution. The new feature, identified as `sequential_full_output`, allows for the collection and return of the outputs from each individual task in a sequential process, rather than just the final task's output.

## Changes
- **New Method `_sequential_loop_full_output`**: Implemented in the main processing class, this method extends the functionality of the existing `_sequential_loop`. It accumulates the outputs of each task in a sequential process and returns them as a list.
- **Process Enumeration Update**: Added `Process.sequential_full_output` to the `Process` enumeration to support the new method.
- **Main Process Handling**: Updated the main processing method to handle the new `Process.sequential_full_output` case, directing it to use the new `_sequential_loop_full_output` method.

## Benefits
- **Flexibility**: It offers additional flexibility for use cases where individual task outputs are required for further processing or analysis.