### PR TITLE
Bug fix hierarchical process manager llm

### DIFF
--- a/src/crewai/crew.py
+++ b/src/crewai/crew.py
@@ -201,6 +201,7 @@ class Crew(BaseModel):
             backstory=i18n.retrieve("hierarchical_manager_agent", "backstory"),
             tools=AgentTools(agents=self.agents).tools(),
             verbose=True,
+            llm=self.manager_llm,
         )
 
         task_output = ""


### PR DESCRIPTION
***When attempting to use a hierarchical process manager with a custom language model (llm), the specified manager_llm parameter is not being utilized. Instead, the default OpenAI model is employed.***

# Steps to Reproduce:

Use any llm other than OpenAI ChatGPT (e.g., Gemini) for the following configuration:
```python
crew = Crew(
            agents=[assistant],
            tasks=[task1],
            verbose=True,
            manager_llm=llm,
            process=Process.hierarchical,
            llm=llm,
        )
```
Observe that the manager_llm parameter is not applied, and the default OpenAI ChatGPT model is used instead.

# Expected Behavior:
The hierarchical process manager should utilize the specified manager_llm parameter, allowing users to customize the language model used for managing processes within the Crew.

# Actual Behavior:
The Crew does not consider the provided manager_llm and defaults to using OpenAI ChatGPT for process management.