### PR TITLE
Update Creating-a-Crew-and-kick-it-off.md to add crewai-tools as dependency

### DIFF
--- a/docs/how-to/Creating-a-Crew-and-kick-it-off.md
+++ b/docs/how-to/Creating-a-Crew-and-kick-it-off.md
@@ -11,6 +11,7 @@ Install CrewAI and any necessary packages for your project. The `duckduckgo-sear
 
 ```shell
 pip install crewai
+pip install crewai-tools
 pip install duckduckgo-search
 ```
 


### PR DESCRIPTION
Without installing crewai-tools, the getting started example does not work, throwing the following error

```
ModuleNotFoundError: No module named 'crewai_tools'
```

This updates the docs to include installing crewai-tools during the installation step.