### PR TITLE
DOC - Update install instruction for crewai[tools]

### DIFF
--- a/docs/how-to/Creating-a-Crew-and-kick-it-off.md
+++ b/docs/how-to/Creating-a-Crew-and-kick-it-off.md
@@ -11,7 +11,7 @@ Install CrewAI and any necessary packages for your project. The `duckduckgo-sear
 
 ```shell
 pip install crewai
-pip install crewai[tools]
+pip install 'crewai[tools]'
 pip install duckduckgo-search
 ```
 


### PR DESCRIPTION
Copy pasting the line `pip install crewai[tools]` didn't work and retuned an error. 
`zsh: no matches found: crewai[tools]`

Correct line is `pip install 'crewai[tools]'` as specified on another documentation https://joaomdmoura.github.io/crewAI/how-to/Customizing-Agents/#performance-and-debugging-settings