### PR TITLE
Docs - fixing doc for the new crewai_tools

### DIFF
--- a/docs/core-concepts/Tools.md
+++ b/docs/core-concepts/Tools.md
@@ -176,7 +176,7 @@ def my_tool(question: str) -> str:
 import json
 import requests
 from crewai import Agent
-from crewai.tools import tool
+from crewai_tools import tool
 from unstructured.partition.html import partition_html
 
     # Annotate the function with the tool decorator from crewAI

--- a/docs/how-to/Create-Custom-Tools.md
+++ b/docs/how-to/Create-Custom-Tools.md
@@ -48,7 +48,7 @@ def my_tool(question: str) -> str:
 import json
 import requests
 from crewai import Agent
-from crewai.tools import tool
+from crewai_tools import tool
 from unstructured.partition.html import partition_html
 
     # Annotate the function with the tool decorator from crewAI


### PR DESCRIPTION
Changing the [docs](https://docs.crewai.com/core-concepts/Tools/#utilizing-the-tool-decorator) for the `crewai_tools` replacing `crewai.tools` to `crewai_tools`. Using the former didn't work on my project, but the latter did.