### PR TITLE
Add version command to CLI

### DIFF
--- a/src/crewai/cli/cli.py
+++ b/src/crewai/cli/cli.py
@@ -21,6 +21,7 @@ def create(project_name):
     "--tools", is_flag=True, help="Show the installed version of crewai tools"
 )
 def version(tools):
+    """Show the installed version of crewai."""
     crewai_version = pkg_resources.get_distribution("crewai").version
     click.echo(f"crewai version: {crewai_version}")
 

--- a/src/crewai/cli/cli.py
+++ b/src/crewai/cli/cli.py
@@ -1,4 +1,5 @@
 import click
+import pkg_resources
 
 from .create_crew import create_crew
 
@@ -13,6 +14,22 @@ def crewai():
 def create(project_name):
     """Create a new crew."""
     create_crew(project_name)
+
+
+@crewai.command()
+@click.option(
+    "--tools", is_flag=True, help="Show the installed version of crewai tools"
+)
+def version(tools):
+    crewai_version = pkg_resources.get_distribution("crewai").version
+    click.echo(f"crewai version: {crewai_version}")
+
+    if tools:
+        try:
+            tools_version = pkg_resources.get_distribution("crewai[tools]").version
+            click.echo(f"crewai tools version: {tools_version}")
+        except pkg_resources.DistributionNotFound:
+            click.echo("crewai tools not installed")
 
 
 if __name__ == "__main__":

--- a/tests/cli_test.py
+++ b/tests/cli_test.py
@@ -1,0 +1,20 @@
+from click.testing import CliRunner
+from crewai.cli.cli import version
+
+
+def test_version_command():
+    runner = CliRunner()
+    result = runner.invoke(version)
+    assert result.exit_code == 0
+    assert "crewai version:" in result.output
+
+
+def test_version_command_with_tools():
+    runner = CliRunner()
+    result = runner.invoke(version, ["--tools"])
+    assert result.exit_code == 0
+    assert "crewai version:" in result.output
+    assert (
+        "crewai tools version:" in result.output
+        or "crewai tools not installed" in result.output
+    )


### PR DESCRIPTION
I mentioned it in Discord then thought it'd be a fun one to tackle and learn a little more about contributing to Python projects.

Example usage:

```bash
$ crewai version
crewai version: 0.22.5
```

```bash
$ crewai version --tools
crewai version: 0.22.5
crewai tools version: 0.22.5
```

Help text:

```bash
$ crewai --help
Usage: crewai [OPTIONS] COMMAND [ARGS]...

  Top-level command group for crewai.

Options:
  --help  Show this message and exit.

Commands:
  create   Create a new crew.
  version  Show the installed version of crewai.
```

```bash
$ crewai version --help
Usage: crewai version [OPTIONS]

  Show the installed version of crewai.

Options:
  --tools  Show the installed version of crewai tools
  --help   Show this message and exit.
```

I added a test as well, lmk if anything else needs to be updated, didn't touch readme or docs as so many things are in motion :wink: 