### PR TITLE
Enable telemetry opt-out #254

### DIFF
--- a/src/crewai/telemetry/telemetry.py
+++ b/src/crewai/telemetry/telemetry.py
@@ -40,6 +40,8 @@ class Telemetry:
     def __init__(self):
         self.ready = False
         try:
+            if os.environ.get("CREWAI_TELEMETRY_OPT_OUT", False):
+                return
             telemetry_endpoint = "http://telemetry.crewai.com:4318"
             self.resource = Resource(
                 attributes={SERVICE_NAME: "crewAI-telemetry"},


### PR DESCRIPTION
Users can opt out of telemetry by setting the environment variable `CREWAI_TELEMETRY_OPT_OUT`

Fixes:

* #254
* #241
* #372