### PR TITLE
tasks.py: don't call Converter when model response is valid

### DIFF
--- a/src/crewai/task.py
+++ b/src/crewai/task.py
@@ -215,6 +215,14 @@ class Task(BaseModel):
 
         if self.output_pydantic or self.output_json:
             model = self.output_pydantic or self.output_json
+
+            if self.output_pydantic:
+                try:
+                    exported_result = model.model_validate_json(result)
+                    return exported_result
+                except Exception:
+                    pass
+
             llm = self.agent.function_calling_llm or self.agent.llm
 
             if not self._is_gpt(llm):


### PR DESCRIPTION
Hello,

Simple PR to try to convert the task output to the expected Pydantic model before sending it to Converter, maybe the model got it right.

This can save a lot of time and money :)
