### PR TITLE
The suggestions were getting split at character level and not at sentence level

### DIFF
--- a/src/crewai/memory/contextual/contextual_memory.py
+++ b/src/crewai/memory/contextual/contextual_memory.py
@@ -43,9 +43,6 @@ class ContextualMemory:
         formatted_results = "\n".join(
             [f"{result['metadata']['suggestions']}" for result in ltm_results]
         )
-        # formatted_results = list(set(formatted_results))
-        # This fix is required to get the unique insights. Without this
-        # it is splitting at char level
         formatted_results = list(set(formatted_results.split('\n')))
         return f"Historical Data:\n{formatted_results}" if ltm_results else ""
 

--- a/src/crewai/memory/contextual/contextual_memory.py
+++ b/src/crewai/memory/contextual/contextual_memory.py
@@ -43,7 +43,10 @@ class ContextualMemory:
         formatted_results = "\n".join(
             [f"{result['metadata']['suggestions']}" for result in ltm_results]
         )
-        formatted_results = list(set(formatted_results))
+        # formatted_results = list(set(formatted_results))
+        # This fix is required to get the unique insights. Without this
+        # it is splitting at char level
+        formatted_results = list(set(formatted_results.split('\n')))
         return f"Historical Data:\n{formatted_results}" if ltm_results else ""
 
     def _fetch_entity_context(self, query) -> str:


### PR DESCRIPTION
When loading the historical suggestions, it was getting loaded as 
 ["Historical Data:\n['e', 'u', '.', 'T', 'n', 'c', 'y', ',', 'v', 't', 'h', 'S', 'A', 'I', 'b', 'f', 'l', 'g', 'd', '-', ' ', '\n', 's', 'a', 'w', 'x', 'p', 'i', 'r', 'k', 'm', 'o']", '', '']

This was happening because the suggestions were split at character level. This fix will not make it at sentence level