### PR TITLE
fix: link to observability

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -79,7 +79,7 @@ Cutting-edge framework for orchestrating role-playing, autonomous AI agents. By 
                 </a>
             </li>
             <li>
-                <a href="./how-to/AgentOps-Observability.md">
+                <a href="./how-to/AgentOps-Observability">
                     Agent Observability using AgentOps
                 </a>
             </li>


### PR DESCRIPTION
Clicking on 

<img width="1439" alt="image" src="https://github.com/joaomdmoura/crewAI/assets/86024/4374e44b-94e2-4130-be7a-2cf2d5b98a9a">


takes you to
<img width="692" alt="image" src="https://github.com/joaomdmoura/crewAI/assets/86024/a152428d-fac0-41b0-9502-1aba797c07ee">
