### PR TITLE
Added optional manager_agent parameter

### DIFF
--- a/src/crewai/crew.py
+++ b/src/crewai/crew.py
@@ -312,6 +312,7 @@ class Crew(BaseModel):
         i18n = I18N(language=self.language, language_file=self.language_file)
         try:
             manager = self.manager_agent
+            manager.allow_delegation = True # Forcing Allow delegation to the manager
         except: 
             manager = Agent(
                 role=i18n.retrieve("hierarchical_manager_agent", "role"),

--- a/src/crewai/crew.py
+++ b/src/crewai/crew.py
@@ -86,6 +86,9 @@ class Crew(BaseModel):
     manager_llm: Optional[Any] = Field(
         description="Language model that will run the agent.", default=None
     )
+    manager_agent: Optional[Any] = Field(
+        description="Custom agent that will be used as manager.", default=None
+    )
     manager_callbacks: Optional[List[InstanceOf[BaseCallbackHandler]]] = Field(
         default=None,
         description="A list of callback handlers to be executed by the manager agent when hierarchical process is used",
@@ -307,14 +310,17 @@ class Crew(BaseModel):
         """Creates and assigns a manager agent to make sure the crew completes the tasks."""
 
         i18n = I18N(language=self.language, language_file=self.language_file)
-        manager = Agent(
-            role=i18n.retrieve("hierarchical_manager_agent", "role"),
-            goal=i18n.retrieve("hierarchical_manager_agent", "goal"),
-            backstory=i18n.retrieve("hierarchical_manager_agent", "backstory"),
-            tools=AgentTools(agents=self.agents).tools(),
-            llm=self.manager_llm,
-            verbose=True,
-        )
+        try:
+            manager = self.manager_agent
+        except: 
+            manager = Agent(
+                role=i18n.retrieve("hierarchical_manager_agent", "role"),
+                goal=i18n.retrieve("hierarchical_manager_agent", "goal"),
+                backstory=i18n.retrieve("hierarchical_manager_agent", "backstory"),
+                tools=AgentTools(agents=self.agents).tools(),
+                llm=self.manager_llm,
+                verbose=True,
+            ) 
 
         task_output = ""
         for task in self.tasks:


### PR DESCRIPTION
As talked about in #466 this adds an optional parameter `manager_agent` in for the `Crew` class. It takes in an `Agent` object that will be used instead of the default one, allowing more granular prompt engineering and even things like scoped delegation.

## Things to consider
- Documentation?
- Check for `allow_delegation` / `tools`?
   - currently it allows delegation to be `False` / there not to be any delegation tools, which would break "crew" functionality
- Could be done easier 
  - user has to make a whole agent 
  - one could also add e.g. `manager_agent_role`, `manager_agent_goal` and `manager_agent_backstory`