### PR TITLE
Prevent duplicate TokenCalcHandler callbacks on Agent

### DIFF
--- a/src/crewai/agent.py
+++ b/src/crewai/agent.py
@@ -161,10 +161,14 @@ class Agent(BaseModel):
         """set agent executor is set."""
         if hasattr(self.llm, "model_name"):
             token_handler = TokenCalcHandler(self.llm.model_name, self._token_process)
-            if isinstance(self.llm.callbacks, list):
+
+            # Ensure self.llm.callbacks is a list
+            if not isinstance(self.llm.callbacks, list):
+                self.llm.callbacks = []
+
+            # Check if an instance of TokenCalcHandler already exists in the list
+            if not any(isinstance(handler, TokenCalcHandler) for handler in self.llm.callbacks):
                 self.llm.callbacks.append(token_handler)
-            else:
-                self.llm.callbacks = [token_handler]
 
         if not self.agent_executor:
             if not self.cache_handler:


### PR DESCRIPTION
It appears that the `TokenCalcHandler` callback is being appended to `Agent.callbacks` multiple times, resulting in an over-estimate of token usage.

Please see comment at: https://github.com/joaomdmoura/crewAI/issues/93#issuecomment-2058258250 for more context.

This PR modifies the behaviour of the `set_agent_executor` method to only allow for a single instance of the handler to be added to an agent. This change will result in more accurate token usage reports.

I have not been able to locate any Github Issues from other users on this topic, so I could be mistaken here. I would greatly appreciate a gut-check from the community on this hypothesis.