### PR TITLE
Add conditional check for output file directory creation

### DIFF
--- a/src/crewai/task.py
+++ b/src/crewai/task.py
@@ -1,6 +1,7 @@
 import threading
 import uuid
 from typing import Any, Dict, List, Optional, Type
+import os
 
 from langchain_openai import ChatOpenAI
 from pydantic import UUID4, BaseModel, Field, field_validator, model_validator
@@ -281,6 +282,11 @@ class Task(BaseModel):
         return isinstance(llm, ChatOpenAI) and llm.openai_api_base == None
 
     def _save_file(self, result: Any) -> None:
+        directory = os.path.dirname(self.output_file)
+
+        if not os.path.exists(directory):
+            os.makedirs(directory)
+
         with open(self.output_file, "w") as file:
             file.write(result)
         return None


### PR DESCRIPTION
This PR adds a conditional check to ensure that the output file directory exists before attempting to create it. This ensures that the code does not fail in cases where the directory does not exist and needs to be created.

The condition is added in the `_save_file` method of the `Task` class, ensuring that the correct behavior is maintained for saving results to a file.