### PR TITLE
docs fix to xml tool import statement

### DIFF
--- a/docs/tools/XMLSearchTool.md
+++ b/docs/tools/XMLSearchTool.md
@@ -17,7 +17,7 @@ pip install 'crewai[tools]'
 Here are two examples demonstrating how to use the XMLSearchTool. The first example shows searching within a specific XML file, while the second example illustrates initiating a search without predefining an XML path, providing flexibility in search scope.
 
 ```python
-from crewai_tools.tools import XMLSearchTool
+from crewai_tools import XMLSearchTool
 
 # Allow agents to search within any XML file's content as it learns about their paths during execution
 tool = XMLSearchTool()

--- a/docs/tools/XMLSearchTool.md
+++ b/docs/tools/XMLSearchTool.md
@@ -17,7 +17,7 @@ pip install 'crewai[tools]'
 Here are two examples demonstrating how to use the XMLSearchTool. The first example shows searching within a specific XML file, while the second example illustrates initiating a search without predefining an XML path, providing flexibility in search scope.
 
 ```python
-from crewai_tools.tools.xml_search_tool import XMLSearchTool
+from crewai_tools.tools import XMLSearchTool
 
 # Allow agents to search within any XML file's content as it learns about their paths during execution
 tool = XMLSearchTool()


### PR DESCRIPTION
Fix to the import statement in XMLSearchTool documentation

This pull request updates the import statement in the `XMLSearchTool.md` file to correctly import the `XMLSearchTool` tool.

## Changes
- Updated the import statement from:
  ```python
  from crewai_tools.tools.xml_search_tool import XMLSearchTool
  ```
  to:
  ```python
  from crewai_tools import XMLSearchTool
  ```

## Reason
The previous import statement was incorrect and would result in an `ImportError` when trying to use the `XMLSearchTool` class. The correct way to import the class is directly from the `crewai_tools.tools` module.

This change ensures that the documentation accurately reflects the correct usage of the `XMLSearchTool` class and helps users avoid potential import issues when following the documentation.

Please let me know if you have any further questions or if there's anything else I can assist with regarding this pull request.