### PR TITLE
feat: adds support to automatically fallback to the default encoding

### DIFF
--- a/src/crewai/utilities/token_counter_callback.py
+++ b/src/crewai/utilities/token_counter_callback.py
@@ -42,9 +42,9 @@ class TokenCalcHandler(BaseCallbackHandler):
     def on_llm_start(
         self, serialized: Dict[str, Any], prompts: List[str], **kwargs: Any
     ) -> None:
-        if "gpt" in self.model:
-            encoding = tiktoken.encoding_for_model(self.model)
-        else:
+        try:
+            encoding = tiktoken.get_encoding(self.model)
+        except KeyError:
             encoding = tiktoken.get_encoding("cl100k_base")
 
         if self.token_cost_process == None:

--- a/src/crewai/utilities/token_counter_callback.py
+++ b/src/crewai/utilities/token_counter_callback.py
@@ -43,7 +43,7 @@ class TokenCalcHandler(BaseCallbackHandler):
         self, serialized: Dict[str, Any], prompts: List[str], **kwargs: Any
     ) -> None:
         try:
-            encoding = tiktoken.get_encoding(self.model)
+            encoding = tiktoken.encoding_for_model(self.model)
         except KeyError:
             encoding = tiktoken.get_encoding("cl100k_base")
 


### PR DESCRIPTION
This PR address an issue with the TokenCalcHandler attempting to classify all "gpt" title models automatically belongs to OpenAI models. This causes an issue if I have a custom model that I call my "gpt-model2" will will result in a key error like below:

```shell
langchain_core.callbacks.manager - WARNING - Error in TokenCalcHandler.on_llm_start callback: KeyError('Could not automatically map azure/gpt4-128k to a tokeniser. Please use `tiktoken.get_encoding` to explicitly get the tokeniser you expect.')
```

Here we attempt to use the gpt model by default and then fall-back to the default encoding one if there was a keyerror.