### PR TITLE
Update on default llm model used in agent.py

### DIFF
--- a/src/crewai/agent.py
+++ b/src/crewai/agent.py
@@ -111,7 +111,7 @@ class Agent(BaseModel):
     i18n: I18N = Field(default=I18N(), description="Internationalization settings.")
     llm: Any = Field(
         default_factory=lambda: ChatOpenAI(
-            model=os.environ.get("OPENAI_MODEL_NAME", "gpt-4")
+            model=os.environ.get("OPENAI_MODEL_NAME", "gpt-4o")
         ),
         description="Language model that will run the agent.",
     )


### PR DESCRIPTION
Changed default model value from gpt-4 to gpt-4o.
Reasoning.
gpt-4 costs 30$ per million tokens while gpt-4o costs 5$. This is more cost friendly for default option.