### PR TITLE
fix for python 3.9 import crewai error [#215]

### DIFF
--- a/src/crewai/task.py
+++ b/src/crewai/task.py
@@ -2,7 +2,7 @@ import os
 import re
 import threading
 import uuid
-from typing import Any, Dict, List, Optional, Type
+from typing import Any, Dict, List, Optional, Type, Union
 
 from langchain_openai import ChatOpenAI
 from pydantic import UUID4, BaseModel, Field, field_validator, model_validator
@@ -146,7 +146,7 @@ class Task(BaseModel):
 
     def execute(  # type: ignore # Missing return statement
         self,
-        agent: Agent | None = None,
+        agent: Union[Agent, None] = None,
         context: Optional[str] = None,
         tools: Optional[List[Any]] = None,
     ) -> str:

--- a/src/crewai/utilities/rpm_controller.py
+++ b/src/crewai/utilities/rpm_controller.py
@@ -12,7 +12,7 @@ class RPMController(BaseModel):
     max_rpm: Union[int, None] = Field(default=None)
     logger: Logger = Field(default=None)
     _current_rpm: int = PrivateAttr(default=0)
-    _timer: threading.Timer | None = PrivateAttr(default=None)
+    _timer: Union[threading.Timer, None] = PrivateAttr(default=None)
     _lock: threading.Lock = PrivateAttr(default=None)
     _shutdown_flag = False
 


### PR DESCRIPTION
This is used to fix for the python 1.10 lower version to use crewai error with: 

```shell

TypeError: unsupported operand type(s) for |: 'type' and 'NoneType' in rpm_controller.py 
```

With the change from `|` to Union type just alike: `max_rpm: Union[int, None] = Field(default=None)` attr.
