### PR TITLE
Update model to ChatOllama, in LLM-Connections.md

### DIFF
--- a/docs/how-to/LLM-Connections.md
+++ b/docs/how-to/LLM-Connections.md
@@ -88,13 +88,12 @@ ollama create $custom_model_name -f ./Llama2ModelFile
 6. Enjoy your free Llama2 model that powered up by excellent agents from crewai.   
 ```
 from crewai import Agent, Task, Crew
-from langchain_openai import ChatOpenAI
+from langchain_community.chat_models import ChatOllama
 import os
 os.environ["OPENAI_API_KEY"] = "NA"
 
-llm = ChatOpenAI(
-    model = "crewai-llama2",
-    base_url = "http://localhost:11434/v1")
+llm = ChatOllama(
+    model = "crewai-llama2")
 
 general_agent = Agent(role = "Math Professor",
                       goal = """Provide the solution to the students that are asking mathematical questions and give them the answer.""",


### PR DESCRIPTION
Hello,

I am currently taking the course on DeepLearning.ai, I noticed in the docs for connecting to Ollama the example provided was using ChatOpenAI. I updated the import for the Ollama llm to be ChatOllama instead of ChatOpenAI.