### PR TITLE
add missing datetime import

### DIFF
--- a/src/crewai/utilities/logger.py
+++ b/src/crewai/utilities/logger.py
@@ -1,5 +1,5 @@
 from crewai.utilities.printer import Printer
-
+from datetime import datetime
 
 class Logger:
     _printer = Printer()


### PR DESCRIPTION
Readme example fails if you are using the latest version of the repo due to the missing import. thought i'd add it quickly while im at it.