### PR TITLE
Fix(690) list index out of range in crew.py

### DIFF
--- a/src/crewai/crew.py
+++ b/src/crewai/crew.py
@@ -276,9 +276,14 @@ class Crew(BaseModel):
         metrics = metrics + [
             agent._token_process.get_summary() for agent in self.agents
         ]
-        self.usage_metrics = {
-            key: sum([m[key] for m in metrics if m is not None]) for key in metrics[0]
-        }
+
+        if metrics:
+            self.usage_metrics = {
+                key: sum([m[key] for m in metrics if m is not None])
+                for key in metrics[0]
+            }
+        else:
+            self.usage_metrics = {}
 
         return result
 

--- a/src/crewai/utilities/logger.py
+++ b/src/crewai/utilities/logger.py
@@ -1,4 +1,5 @@
 from crewai.utilities.printer import Printer
+from datetime import datetime
 
 
 class Logger:
@@ -13,6 +14,7 @@ class Logger:
     def log(self, level, message, color="bold_green"):
         level_map = {"debug": 1, "info": 2}
         if self.verbose_level and level_map.get(level, 0) <= self.verbose_level:
-            timestamp = datetime.now().strftime('%Y-%m-%d %H:%M:%S')
-            self._printer.print(f"[{timestamp}][{level.upper()}]: {message}", color=color)
-
+            timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+            self._printer.print(
+                f"[{timestamp}][{level.upper()}]: {message}", color=color
+            )


### PR DESCRIPTION
**Handle empty metrics list to avoid IndexError in crew.py mentioned in https://github.com/joaomdmoura/crewAI/issues/690**
- Added a condition to check if the metrics list is empty before accessing its elements.
- This prevents IndexError by setting self.usage_metrics to an empty dictionary if metrics is empty.

**fix(logger): Resolve NameError by importing datetime module**
- Added missing import for datetime module to resolve NameError.
- Ensured datetime is correctly used in the log method for timestamp generation.