### PR TITLE
fix: 'from datetime import datetime for logging' to print the timestamp

### DIFF
--- a/src/crewai/utilities/logger.py
+++ b/src/crewai/utilities/logger.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from crewai.utilities.printer import Printer
 
 
@@ -13,6 +14,7 @@ class Logger:
     def log(self, level, message, color="bold_green"):
         level_map = {"debug": 1, "info": 2}
         if self.verbose_level and level_map.get(level, 0) <= self.verbose_level:
-            timestamp = datetime.now().strftime('%Y-%m-%d %H:%M:%S')
-            self._printer.print(f"[{timestamp}][{level.upper()}]: {message}", color=color)
-
+            timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+            self._printer.print(
+                f"[{timestamp}][{level.upper()}]: {message}", color=color
+            )


### PR DESCRIPTION
`from datetime import datetime` was missing from src/crewai/utilities/logger.py

A picture says a thousand words

before
![image](https://github.com/joaomdmoura/crewAI/assets/2087867/15a65cd4-6738-47ef-8d79-4d6a11c97450)

after
![image](https://github.com/joaomdmoura/crewAI/assets/2087867/fe7212bf-e17c-472b-81af-e5bfee70d4ee)


