### PR TITLE
added usage_metrics to full output

### DIFF
--- a/src/crewai/crew.py
+++ b/src/crewai/crew.py
@@ -431,7 +431,8 @@ class Crew(BaseModel):
             "_cache_handler",
             "_short_term_memory",
             "_long_term_memory",
-            "_entity_memory" "agents",
+            "_entity_memory",
+            "agents",
             "tasks",
         }
 

--- a/src/crewai/crew.py
+++ b/src/crewai/crew.py
@@ -48,7 +48,7 @@ class Crew(BaseModel):
         max_rpm: Maximum number of requests per minute for the crew execution to be respected.
         prompt_file: Path to the prompt json file to be used for the crew.
         id: A unique identifier for the crew instance.
-        full_output: Whether the crew should return the full output with all tasks outputs or just the final output.
+        full_output: Whether the crew should return the full output with all tasks outputs and token usage metrics or just the final output.
         task_callback: Callback to be executed after each task for every agents execution.
         step_callback: Callback to be executed after each step for every agents execution.
         share_crew: Whether you want to share the complete crew information and execution with crewAI to make the library better, and allow us to train models.
@@ -84,7 +84,7 @@ class Crew(BaseModel):
     )
     full_output: Optional[bool] = Field(
         default=False,
-        description="Whether the crew should return the full output with all tasks outputs or just the final output.",
+        description="Whether the crew should return the full output with all tasks outputs and token usage metrics or just the final output.",
     )
     manager_llm: Optional[Any] = Field(
         description="Language model that will run the agent.", default=None

--- a/src/crewai/crew.py
+++ b/src/crewai/crew.py
@@ -377,8 +377,9 @@ class Crew(BaseModel):
                 self._file_handler.log(agent=role, task=task_output, status="completed")
 
         self._finish_execution(task_output)
-        # type: ignore # Incompatible return value type (got "tuple[str, Any]", expected "str")
+        # type: ignore # Item "None" of "Agent | None" has no attribute "_token_process"
         token_usage = task.agent._token_process.get_summary()
+        # type: ignore # Incompatible return value type (got "tuple[str, Any]", expected "str")
         return self._format_output(task_output, token_usage)
 
     def _run_hierarchical_process(self) -> str:
@@ -485,6 +486,7 @@ class Crew(BaseModel):
             }
             if self.output_token_usage and token_usage:
                 formatted_output["token_usage"] = token_usage
+            # type: ignore # Incompatible return value type (got " dict[str, Any]", expected "str")
             return formatted_output
         else:
             return output

--- a/src/crewai/task.py
+++ b/src/crewai/task.py
@@ -236,8 +236,7 @@ class Task(BaseModel):
 
         if inputs:
             self.description = self._original_description.format(**inputs)
-            self.expected_output = self._original_expected_output.format(
-                **inputs)
+            self.expected_output = self._original_expected_output.format(**inputs)
 
     def increment_tools_errors(self) -> None:
         """Increment the tools errors counter."""
@@ -259,11 +258,18 @@ class Task(BaseModel):
         copied_data = self.model_dump(exclude=exclude)
         copied_data = {k: v for k, v in copied_data.items() if v is not None}
 
-        cloned_context = [task.copy() for task in self.context] if self.context else None
+        cloned_context = (
+            [task.copy() for task in self.context] if self.context else None
+        )
         cloned_agent = self.agent.copy() if self.agent else None
         cloned_tools = deepcopy(self.tools) if self.tools else None
 
-        copied_task = Task(**copied_data, context=cloned_context, agent=cloned_agent, tools=cloned_tools)
+        copied_task = Task(
+            **copied_data,
+            context=cloned_context,
+            agent=cloned_agent,
+            tools=cloned_tools,
+        )
         return copied_task
 
     def _export_output(self, result: str) -> Any:
@@ -287,8 +293,7 @@ class Task(BaseModel):
                 if match:
                     try:
                         # type: ignore # Item "None" of "type[BaseModel] | None" has no attribute "model_validate_json"
-                        exported_result = model.model_validate_json(
-                            match.group(0))
+                        exported_result = model.model_validate_json(match.group(0))
                         if self.output_json:
                             # type: ignore # "str" has no attribute "model_dump"
                             return exported_result.model_dump()
@@ -302,8 +307,7 @@ class Task(BaseModel):
             if not self._is_gpt(llm):
                 # type: ignore # Argument "model" to "PydanticSchemaParser" has incompatible type "type[BaseModel] | None"; expected "type[BaseModel]"
                 model_schema = PydanticSchemaParser(model=model).get_schema()
-                instructions = f"{
-                    instructions}\n\nThe json should have the following structure, with the following keys:\n{model_schema}"
+                instructions = f"{instructions}\n\nThe json should have the following structure, with the following keys:\n{model_schema}"
 
             converter = Converter(
                 llm=llm, text=result, model=model, instructions=instructions
@@ -316,8 +320,7 @@ class Task(BaseModel):
 
             if isinstance(exported_result, ConverterError):
                 Printer().print(
-                    content=f"{
-                        exported_result.message} Using raw output instead.",
+                    content=f"{exported_result.message} Using raw output instead.",
                     color="red",
                 )
                 exported_result = result
@@ -342,7 +345,7 @@ class Task(BaseModel):
             os.makedirs(directory)
 
         # type: ignore # Argument 1 to "open" has incompatible type "str | None"; expected "int | str | bytes | PathLike[str] | PathLike[bytes]"
-        with open(self.output_file, "w", encoding='utf-8') as file:
+        with open(self.output_file, "w", encoding="utf-8") as file:
             file.write(result)
         return None
 

--- a/src/crewai/utilities/logger.py
+++ b/src/crewai/utilities/logger.py
@@ -1,6 +1,5 @@
 from datetime import datetime
 from crewai.utilities.printer import Printer
-from datetime import datetime
 
 
 class Logger:

--- a/tests/crew_test.py
+++ b/tests/crew_test.py
@@ -690,6 +690,23 @@ def test_agent_usage_metrics_are_captured_for_hierarchical_process():
     }
 
 
+def test_crew_outputs_token_usage_flag():
+    agent = Agent(
+        role="Researcher",
+        goal="Be super empathetic.",
+        backstory="You love to say howdy.",
+        allow_delegation=False,
+    )
+    task = Task(description="Say howdy", expected_output="Howdy!", agent=agent)
+
+    crew = Crew(agents=[agent], tasks=[task])
+    result = crew.kickoff(output_token_usage=True)
+    assert (
+        result
+        == "Howdy!\n--------\nTOKEN USAGE:\ntotal_tokens=176\nprompt_tokens=158\ncompletion_tokens=18\nsuccessful_requests=1"
+    )
+
+
 def test_crew_inputs_interpolate_both_agents_and_tasks():
     agent = Agent(
         role="{topic} Researcher",

--- a/tests/crew_test.py
+++ b/tests/crew_test.py
@@ -699,8 +699,8 @@ def test_crew_outputs_token_usage_flag():
     )
     task = Task(description="Say howdy", expected_output="Howdy!", agent=agent)
 
-    crew = Crew(agents=[agent], tasks=[task])
-    result = crew.kickoff(output_token_usage=True)
+    crew = Crew(agents=[agent], tasks=[task], output_token_usage=True)
+    result = crew.kickoff()
     assert (
         result
         == "Howdy!\n--------\nTOKEN USAGE:\ntotal_tokens=176\nprompt_tokens=158\ncompletion_tokens=18\nsuccessful_requests=1"

--- a/tests/crew_test.py
+++ b/tests/crew_test.py
@@ -384,6 +384,12 @@ def test_crew_full_ouput():
     assert result == {
         "final_output": "Hello! It is a delight to receive your message. I trust this response finds you in good spirits. It's indeed a pleasure to connect with you too.",
         "tasks_outputs": [task1.output, task2.output],
+        "usage_metrics": {
+            "completion_tokens": 109,
+            "prompt_tokens": 330,
+            "successful_requests": 2,
+            "total_tokens": 439,
+        },
     }
 
 
@@ -688,23 +694,6 @@ def test_agent_usage_metrics_are_captured_for_hierarchical_process():
         "completion_tokens": 283,
         "successful_requests": 3,
     }
-
-
-def test_crew_outputs_token_usage_flag():
-    agent = Agent(
-        role="Researcher",
-        goal="Be super empathetic.",
-        backstory="You love to say howdy.",
-        allow_delegation=False,
-    )
-    task = Task(description="Say howdy", expected_output="Howdy!", agent=agent)
-
-    crew = Crew(agents=[agent], tasks=[task], output_token_usage=True)
-    result = crew.kickoff()
-    assert (
-        result
-        == "Howdy!\n--------\nTOKEN USAGE:\ntotal_tokens=176\nprompt_tokens=158\ncompletion_tokens=18\nsuccessful_requests=1"
-    )
 
 
 def test_crew_inputs_interpolate_both_agents_and_tasks():


### PR DESCRIPTION
…esult

Feature Added for #162 

Added onto the Crew Class which takes in output_token_usage

Adds to full_output and to the result  

## Usage
```py
Crew(
    agents=[agent],
    tasks=[task1],
    process=Process.sequential,
    full_output=True,
    verbose=True,
    output_token_usage=True,
)
```


## Output:

Howdy! 
(-------)
TOKEN USAGE:
total_tokens=176
prompt_tokens=158
completion_tokens=18
successful_requests=1

and or like this when full_output = True
`{'final_output': 'Hi!', 'tasks_outputs': [TaskOutput(description='just say hi!', summary='just say hi!...', exported_output='Hi!', agent='test role', raw_output='Hi!')], 'token_usage': {'total_tokens': 169, 'prompt_tokens': 152, 'completion_tokens': 17, 'successful_requests': 1}}`