### PR TITLE
fix: Fix grammar error in documentation in PDF Search Tool

### DIFF
--- a/docs/tools/PDFSearchTool.md
+++ b/docs/tools/PDFSearchTool.md
@@ -29,7 +29,7 @@ tool = PDFSearchTool(pdf='path/to/your/document.pdf')
 ```
 
 ## Arguments
-- `pdf`: **Optinal** The PDF path for the search. Can be provided at initialization or within the `run` method's arguments. If provided at initialization, the tool confines its search to the specified document.
+- `pdf`: **Optional** The PDF path for the search. Can be provided at initialization or within the `run` method's arguments. If provided at initialization, the tool confines its search to the specified document.
 
 ## Custom model and embeddings
 


### PR DESCRIPTION
Correction of grammar error in the CrewAI documentation, on the page 'https://docs.crewai.com/tools/PDFSearchTool/' it says 'Optinal' instead of 'Optional'.