### PR TITLE
Fix definition of RAG in GithubTool docs

### DIFF
--- a/docs/tools/GitHubSearchTool.md
+++ b/docs/tools/GitHubSearchTool.md
@@ -4,7 +4,7 @@
     We are still working on improving tools, so there might be unexpected behavior or changes in the future.
 
 ## Description
-The GithubSearchTool is a Read, Append, and Generate (RAG) tool specifically designed for conducting semantic searches within GitHub repositories. Utilizing advanced semantic search capabilities, it sifts through code, pull requests, issues, and repositories, making it an essential tool for developers, researchers, or anyone in need of precise information from GitHub.
+The GithubSearchTool is a Retrieval-Augmented Generation (RAG) tool specifically designed for conducting semantic searches within GitHub repositories. Utilizing advanced semantic search capabilities, it sifts through code, pull requests, issues, and repositories, making it an essential tool for developers, researchers, or anyone in need of precise information from GitHub.
 
 ## Installation
 To use the GithubSearchTool, first ensure the crewai_tools package is installed in your Python environment:


### PR DESCRIPTION
Correct the definition of RAG in the description of the `GithubSearchTool` from "Read, Append, and Generate" to "Retrieval-Augmented Generation".

