### PR TITLE
passing cloned agents when copying context

### DIFF
--- a/src/crewai/task.py
+++ b/src/crewai/task.py
@@ -292,7 +292,7 @@ class Task(BaseModel):
         copied_data = {k: v for k, v in copied_data.items() if v is not None}
 
         cloned_context = (
-            [task.copy() for task in self.context] if self.context else None
+            [task.copy(agents) for task in self.context] if self.context else None
         )
 
         def get_agent_by_role(role: str) -> Union["BaseAgent", None]:


### PR DESCRIPTION
I was testing kickoff_for_each and figure out when i have only tasks without context in crew the copy works well, but when i add some context from other tasks the task.copy breaks, this was happen because the copy of task to clone the context dont pass the cloned agents, so the get_agent_by_role dont work, i dont know if this is the best fix for this problem, but i hope i can hear you opinions soon.

Thanks.